### PR TITLE
latest changes, including more understanable output for mentors and short teams command

### DIFF
--- a/src/cogs/pods.py
+++ b/src/cogs/pods.py
@@ -109,6 +109,37 @@ class Pods(commands.Cog, name="Pods"):
         for team in teams:
             await current_channel.send(embed=GenerateEmbed.for_single_showcase_team(team, False))
 
+    @commands.command(name='teams_short', aliases=['list-teams_short', 'list_teams_short', 'listteams_short'])
+    @checks.requires_mentor_role()
+    async def teams_short(self, ctx: commands.Context, pod_name_or_discord_user: Union[str, discord.Member] = None):
+        """Displays TEAMS of a POD or DISCORD MEMBER in CURRENT CHANNEL WITHOUT EMBEDS"""
+        current_channel: discord.TextChannel = ctx.channel
+        await current_channel.send("I'm working my gears, let me find the teams, give me a couple seconds...")
+        teams = await TeamConverter.get_teams(current_channel, pod_name_or_discord_user)
+        if len(teams) == 0 or teams is None:
+            return
+
+        print("here")
+        is_pod: bool = PodConverter.is_pod(pod_name_or_discord_user)
+
+        if is_pod:
+            await current_channel.send(f"I found a couple of projects for Pod {pod_name_or_discord_user}, "
+                                       f"give me a few seconds to show them to you...")
+        else:
+            is_mentor_pod = True if pod_name_or_discord_user is None else False
+            if is_mentor_pod:
+                await current_channel.send(f"I found a couple of projects for your pod, "
+                                           f"give me a few seconds to show them to you...")
+            else:
+                await current_channel.send(f"I found a couple of projects for {pod_name_or_discord_user}, "
+                                           f"give me a few seconds to show them to you...")
+        for team in teams:
+            member_mentions = []
+            for showcase_member in team["members"]:
+                member_mentions.append(f"<@{str(showcase_member['account']['discordId'])}>")
+            await current_channel.send(f"Team Name: {team['name']}\n"
+                                       f"Members: {', '.join(member_mentions)}")
+
     @commands.command(name='pods', aliases=['list_pods', 'list-pods, list_all_pods', 'listpods'])
     @checks.requires_staff_role()
     async def pods(self, ctx: commands.Context):

--- a/src/cogs/pods.py
+++ b/src/cogs/pods.py
@@ -87,19 +87,25 @@ class Pods(commands.Cog, name="Pods"):
     async def teams(self, ctx: commands.Context, pod_name_or_discord_user: Union[str, discord.Member] = None):
         """Displays TEAMS of a POD or DISCORD MEMBER in CURRENT CHANNEL"""
         current_channel: discord.TextChannel = ctx.channel
+        await current_channel.send("I'm working my gears, let me find the teams, give me a couple seconds...")
         teams = await TeamConverter.get_teams(current_channel, pod_name_or_discord_user)
         if len(teams) == 0 or teams is None:
             return
 
+        print("here")
         is_pod: bool = PodConverter.is_pod(pod_name_or_discord_user)
 
         if is_pod:
             await current_channel.send(f"I found a couple of projects for Pod {pod_name_or_discord_user}, "
                                        f"give me a few seconds to show them to you...")
         else:
-            await current_channel.send(f"I found a couple of projects for {pod_name_or_discord_user}, "
-                                       f"give me a few seconds to show them to you...")
-
+            is_mentor_pod = True if pod_name_or_discord_user is None else False
+            if is_mentor_pod:
+                await current_channel.send(f"I found a couple of projects for your pod, "
+                                           f"give me a few seconds to show them to you...")
+            else:
+                await current_channel.send(f"I found a couple of projects for {pod_name_or_discord_user}, "
+                                           f"give me a few seconds to show them to you...")
         for team in teams:
             await current_channel.send(embed=GenerateEmbed.for_single_showcase_team(team, False))
 

--- a/src/cogs/pods.py
+++ b/src/cogs/pods.py
@@ -133,12 +133,14 @@ class Pods(commands.Cog, name="Pods"):
             else:
                 await current_channel.send(f"I found a couple of projects for {pod_name_or_discord_user}, "
                                            f"give me a few seconds to show them to you...")
+        message = ""
         for team in teams:
             member_mentions = []
             for showcase_member in team["members"]:
                 member_mentions.append(f"<@{str(showcase_member['account']['discordId'])}>")
-            await current_channel.send(f"Team Name: {team['name']}\n"
-                                       f"Members: {', '.join(member_mentions)}")
+            message += f"Team Name: {team['name']}\n " \
+                       f"Members: {', '.join(member_mentions)}\n\n"
+        await current_channel.send(message)
 
     @commands.command(name='pods', aliases=['list_pods', 'list-pods, list_all_pods', 'listpods'])
     @checks.requires_staff_role()

--- a/src/cogs/pods.py
+++ b/src/cogs/pods.py
@@ -94,9 +94,11 @@ class Pods(commands.Cog, name="Pods"):
         is_pod: bool = PodConverter.is_pod(pod_name_or_discord_user)
 
         if is_pod:
-            await current_channel.send(f"I found a couple of projects for Pod {pod_name_or_discord_user}")
+            await current_channel.send(f"I found a couple of projects for Pod {pod_name_or_discord_user}, "
+                                       f"give me a few seconds to show them to you...")
         else:
-            await current_channel.send(f"I found a couple of projects for {pod_name_or_discord_user}")
+            await current_channel.send(f"I found a couple of projects for {pod_name_or_discord_user}, "
+                                       f"give me a few seconds to show them to you...")
 
         for team in teams:
             await current_channel.send(embed=GenerateEmbed.for_single_showcase_team(team, False))

--- a/src/converters/PodConverter.py
+++ b/src/converters/PodConverter.py
@@ -97,4 +97,6 @@ class PodConverter:
 
     @staticmethod
     def is_pod(pod_name) -> bool:
+        if pod_name is None:
+            return False
         return True if PodDBService.get_pod_by_name(pod_name) is not None else False

--- a/src/converters/TeamConverter.py
+++ b/src/converters/TeamConverter.py
@@ -29,12 +29,10 @@ class TeamConverter:
     @staticmethod
     async def get_teams(current_channel: discord.TextChannel,
                         pod_name_or_discord_user: str = None):
-        print(pod_name_or_discord_user)
         if pod_name_or_discord_user is None:
             teams = []
             pod = await PodConverter.get_pod_by_channel_id(current_channel.id,
                                                            current_channel=current_channel)
-
             await TeamConverter.check_if_teams_exist(teams=pod.teams,
                                                      output_channel=current_channel,
                                                      output=f"There are no projects in Pod {pod.name} yet. Project(s) "
@@ -43,21 +41,17 @@ class TeamConverter:
                 showcase_team = await TeamConverter.get_showcase_team_by_id(team.showcase_id)
                 teams.append(showcase_team)
             return teams
-        if pod_name_or_discord_user[0] == "<":  # discord username given
+        elif pod_name_or_discord_user[0] == "<":  # discord username given
             filter_out = "<!@>"
             for char in filter_out:
                 pod_name_or_discord_user = pod_name_or_discord_user.replace(char, '')
-            print(pod_name_or_discord_user)
             user = await PodGQLService.get_showcase_user_from_discord_id(str(pod_name_or_discord_user))
-            print(user['username'])
             teams = await PodGQLService.get_showcase_team_by_showcase_user(user['username'])
-            print(teams)
             await TeamConverter.check_if_teams_exist(teams=teams,
                                                      output_channel=current_channel,
                                                      output=f"<@{pod_name_or_discord_user}> does not belong to any projects.")
             return teams
         else:  # assume pod name is given
-            print("is string")
             teams = []
             pod = await PodConverter.get_pod_by_name(pod_name=pod_name_or_discord_user,
                                                      current_channel=current_channel)


### PR DESCRIPTION
- Fixed a problem where s~teams inside of a pods channel wasn't returning the teams
- Removed some more print statements
- Added a s~teams_short command where it will send all teams in a single message instead of a multiple message embeds
- Made it extra clear what the bot was doing when it was taking time
- More output clarity so mentors know whats up 